### PR TITLE
Merging LogoLink into Development

### DIFF
--- a/cise-react-learn/src/App.js
+++ b/cise-react-learn/src/App.js
@@ -11,7 +11,7 @@ function App() {
         </p>
         <a
           className="App-link"
-          href="https://reactjs.org"
+          href="https://aut.ac.nz"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Change has been made where the link will take the user to aut website not react.org.